### PR TITLE
Added counter effects to stats section issue number #19

### DIFF
--- a/frontend/src/components/Counter.jsx
+++ b/frontend/src/components/Counter.jsx
@@ -1,0 +1,25 @@
+import React, { useState, useEffect } from "react";
+
+function Counter({ targetNumber = 0, display, duration = 1000 }) {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    let start = 0;
+    const increment = targetNumber / (duration / 50);
+
+    const timer = setInterval(() => {
+      start += increment;
+      if (start >= targetNumber) {
+        clearInterval(timer);
+        setCount(targetNumber);
+      } else {
+        setCount(Math.floor(start));
+      }
+    }, 50);
+
+    return () => clearInterval(timer);
+  }, [targetNumber, duration]);
+
+  return <>{display ? display.replace(/^\d+/, count) : count}</>;
+}
+export default Counter;

--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -1,3 +1,4 @@
+import Counter from "./Counter.jsx";
 import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { 
@@ -82,12 +83,13 @@ const ModernLandingPage = () => {
     }
   ];
 
-  const stats = [
-    { number: "10K+", label: "Active Warriors", icon: Users },
-    { number: "50K+", label: "Battles Completed", icon: Swords },
-    { number: "<1ms", label: "Response Time", icon: Zap },
-    { number: "24/7", label: "Always Online", icon: Earth }
-  ];
+const stats = [
+  { value: 10, display: "10K+", label: "Active Warriors", icon: Users },
+  { value: 500, display: "50K+", label: "Battles Completed", icon: Swords },
+  { value: 1, display: "<1ms", label: "Response Time", icon: Zap },
+  { value: 24, display: "24/7", label: "Always Online", icon: Earth }
+];
+
 
   // Animation variants
   const containerVariants = {
@@ -353,7 +355,7 @@ const ModernLandingPage = () => {
                   animate={{ scale: 1 }}
                   transition={{ delay: 0.5 + index * 0.1, type: "spring" }}
                 >
-                  {stat.number}
+                  <Counter targetNumber={stat.value} display={stat.display} duration={2000} />
                 </motion.div>
                 <div className="text-sm text-gray-400">{stat.label}</div>
               </motion.div>


### PR DESCRIPTION
This PR introduces an animated counter effect to the stats section, making the numeric values smoothly increment from 0 to their target values.

Issue number:#19

## Changes
- Created `Counter` component for reusable number animations.
- Updated stats section to use `Counter` instead of static numbers.
- Preserves suffixes like `K+`, `/7`, and `<1ms` while animating only the numeric portion.

https://github.com/user-attachments/assets/45b9dfbf-9c36-437d-85e5-61118551b6ae

