### PR TITLE
🔼 Feature Request: Add "Back to Top" Arrow for Easy Navigation #21

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import Footer from './components/Footer';
 import PrivacyPolicyPage from './pages/PrivacyPolicyPage';
 import TermsOfServicePage from './pages/TermsofServicePage';
 import Contact from './pages/Contact'
+import BackToTopButton from "./components/BackToTopButton";
 
 class ErrorBoundary extends Component {
   state = { hasError: false };
@@ -38,6 +39,7 @@ function App() {
           <Route path='/contact-us' element={<Contact/>}/>
         </Routes>
         <Footer/>
+        <BackToTopButton />
       </ErrorBoundary>
     </div>
   );

--- a/frontend/src/components/BackToTopButton.jsx
+++ b/frontend/src/components/BackToTopButton.jsx
@@ -1,0 +1,59 @@
+// src/components/BackToTopButton.jsx
+import React, { useState, useEffect } from "react";
+
+const BackToTopButton = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsVisible(window.scrollY > 300);
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label="Scroll to top"
+      tabIndex={0}
+      onClick={scrollToTop}
+      className={`fixed bottom-6 right-6 z-50 p-3 rounded-full shadow-lg transition-colors duration-200
+        bg-gradient-to-br from-indigo-500 to-purple-500
+        hover:from-indigo-600 hover:to-purple-600
+        focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-2
+        ${isVisible ? "opacity-100" : "opacity-0 pointer-events-none"}
+      `}
+      style={{
+        transition: "opacity 0.4s",
+        boxShadow: "0 4px 14px rgba(0,0,0,0.15)",
+      }}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        className="w-6 h-6 text-white"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M5 15l7-7 7 7"
+        />
+      </svg>
+    </button>
+  );
+};
+
+export default BackToTopButton;


### PR DESCRIPTION

## 🔼 Pull Request: Add "Back to Top" Arrow for Easy Navigation  

### 📌 Related Issue  
Closes (https://github.com/dinesh-2047/LoopWar/issues/21)

***

### ✨ Description  
This PR implements a **“Back to Top” button/arrow** that enhances navigation and user experience across long pages.  

- Button is **hidden by default** and becomes visible after scrolling **300px**.  
- Clicking the button smoothly scrolls the page back to the top (`behavior: "smooth"`).  
- Positioned **fixed** at the bottom-right corner without overlapping other UI.  
- Styled in line with **LoopWar’s theme** (minimalist design, shadow, hover effects).  
- **Responsive and accessible**:  
  - Works across desktop & mobile devices.  
  - Includes `aria-label` for screen readers.  
  - Supports keyboard navigation.  

***

### 🛠️ Changes Made  
- **`App.jsx`**: Integrated `BackToTopButton` component.  
- **`BackToTopButton.jsx`**: Created a new reusable component with scroll logic and smooth animation.  


***

### 📸 Screenshots (Before / After)  
<img width="1918" height="885" alt="Screenshot 2025-08-16 121536" src="https://github.com/user-attachments/assets/9df88109-ad09-48d1-a52e-8963715fba6e" />
<img width="1919" height="929" alt="Screenshot 2025-08-16 121608" src="https://github.com/user-attachments/assets/a4dc3452-f1d2-4af3-ba0c-be68994b5623" />
<img width="1919" height="881" alt="Screenshot 2025-08-16 121626" src="https://github.com/user-attachments/assets/f7ac21fe-0246-412e-b385-442cbfae07ca" />


***

### 🎯 Testing Done  
- Verified on Chrome, Firefox, and Edge.  
- Tested mobile responsiveness (via browser dev tools).  
- Confirmed accessibility with screen reader and keyboard navigation.  

***

### ✅ Checklist  
- [x] Code follows project coding standards  
- [x] Responsive design tested  
- [x] Works across modern browsers  
- [x] Accessibility features included  
- [x] Issue (https://github.com/dinesh-2047/LoopWar/issues/21) closed

